### PR TITLE
Fable 5 / Anthropic-provider compatibility fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ OPENROUTER_API_KEY=
 # LM Studio: any non-empty string works
 # OPENAI_API_KEY=lm-studio
 
-# Anthropic: only if using --provider anthropic
+# Anthropic: only if using --provider anthropic (auto-bridged to process env)
 # ANTHROPIC_API_KEY=sk-ant-...
 
 # --- RIMAPI (RimWorld mod) ---

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -26,7 +26,7 @@ from rle.agents.medical_officer import MedicalOfficer
 from rle.agents.research_director import ResearchDirector
 from rle.agents.resource_manager import ResourceManager
 from rle.agents.social_overseer import SocialOverseer
-from rle.config import RLEConfig, bridge_openrouter_key
+from rle.config import RLEConfig, bridge_anthropic_key, bridge_openrouter_key
 from rle.orchestration.game_loop import RLEGameLoop
 from rle.rimapi.client import RimAPIClient
 from rle.scenarios.evaluator import ScenarioEvaluator
@@ -356,6 +356,7 @@ def _build_provider(args: argparse.Namespace) -> tuple[BaseProvider, RLEConfig]:
         overrides["provider_base_url"] = args.base_url
     config = RLEConfig(**overrides) if overrides else RLEConfig()
     bridge_openrouter_key(config)
+    bridge_anthropic_key(config)
     return config.get_provider(), config
 
 
@@ -525,10 +526,14 @@ async def main(args: argparse.Namespace) -> None:
 
     num_runs = getattr(args, "runs", 1) or 1
 
+    # extra_body is an OpenAI-compatible escape hatch; the Anthropic API
+    # rejects unknown body fields with 400.
+    effective_provider = args.provider or config.provider
+
     if args.ablation:
         ticks_override = _resolve_ticks(args, use_mock_rimapi)
         provider_kwargs_abl: dict[str, Any] = {}
-        if args.no_think:
+        if args.no_think and effective_provider != "anthropic":
             provider_kwargs_abl["extra_body"] = {
                 "chat_template_kwargs": {"enable_thinking": False},
             }
@@ -553,7 +558,7 @@ async def main(args: argparse.Namespace) -> None:
 
     # Build provider kwargs (e.g. no-think for Qwen3.5)
     provider_kwargs: dict[str, Any] = {}
-    if args.no_think:
+    if args.no_think and effective_provider != "anthropic":
         provider_kwargs["extra_body"] = {
             "chat_template_kwargs": {"enable_thinking": False},
         }

--- a/scripts/run_scenario.py
+++ b/scripts/run_scenario.py
@@ -21,7 +21,7 @@ from rle.agents.medical_officer import MedicalOfficer
 from rle.agents.research_director import ResearchDirector
 from rle.agents.resource_manager import ResourceManager
 from rle.agents.social_overseer import SocialOverseer
-from rle.config import RLEConfig, bridge_openrouter_key
+from rle.config import RLEConfig, bridge_anthropic_key, bridge_openrouter_key
 from rle.docker import wait_for_rimapi
 from rle.orchestration.game_loop import RLEGameLoop
 from rle.rimapi.client import RimAPIClient
@@ -175,6 +175,7 @@ async def main(args: argparse.Namespace) -> None:
         overrides["tick_interval"] = str(args.tick_interval)
     config = RLEConfig(**overrides) if overrides else RLEConfig()
     bridge_openrouter_key(config)
+    bridge_anthropic_key(config)
     provider = config.get_provider()
     helix = HelixConfig.default().to_geometry()
     agents = _create_agents(provider, helix)

--- a/src/rle/agents/base_role.py
+++ b/src/rle/agents/base_role.py
@@ -167,7 +167,12 @@ class RimWorldRoleAgent(LLMAgent):
         self._provider_kwargs = kwargs
 
     def set_no_think(self, enabled: bool = True) -> None:
-        """Enable no-think mode: skips reasoning via </think> assistant prefix."""
+        """Enable no-think mode: skips reasoning via </think> assistant prefix.
+
+        No-op on the anthropic provider: Claude 4.6+ rejects trailing
+        assistant prefills with HTTP 400, and Claude skips reasoning by
+        omitting the thinking param anyway.
+        """
         self._no_think = enabled
 
     def attach_spoke(self, spoke: Spoke) -> None:
@@ -218,7 +223,7 @@ class RimWorldRoleAgent(LLMAgent):
             ChatMessage(role=MessageRole.SYSTEM, content=system_prompt),
             ChatMessage(role=MessageRole.USER, content=user_prompt),
         ]
-        if self._no_think:
+        if self._no_think and self.provider.provider_name != "anthropic":
             messages.append(
                 ChatMessage(role=MessageRole.ASSISTANT, content="</think>"),
             )

--- a/src/rle/config.py
+++ b/src/rle/config.py
@@ -36,6 +36,7 @@ class RLEConfig(BaseSettings):
     model: str = "claude-sonnet-4-5"
     provider_base_url: str | None = None
     openrouter_api_key: str | None = None
+    anthropic_api_key: str | None = None
     tick_interval: float = 1.0
     role_timeout_s: float = 60.0
     """Max wall-clock seconds for a single agent's deliberation. Hung LLM
@@ -77,3 +78,13 @@ def bridge_openrouter_key(config: RLEConfig) -> None:
     """If OPENROUTER_API_KEY is set but OPENAI_API_KEY isn't, bridge them."""
     if config.openrouter_api_key and not os.environ.get("OPENAI_API_KEY"):
         os.environ["OPENAI_API_KEY"] = config.openrouter_api_key
+
+
+def bridge_anthropic_key(config: RLEConfig) -> None:
+    """Export ANTHROPIC_API_KEY from .env so the felix provider can read it.
+
+    pydantic-settings loads .env into the config object but not into
+    os.environ, which is where AnthropicProvider looks for the key.
+    """
+    if config.anthropic_api_key and not os.environ.get("ANTHROPIC_API_KEY"):
+        os.environ["ANTHROPIC_API_KEY"] = config.anthropic_api_key

--- a/tests/unit/test_base_role.py
+++ b/tests/unit/test_base_role.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 from felix_agent_sdk import LLMResult
 from felix_agent_sdk.core import HelixGeometry
-from felix_agent_sdk.providers.types import CompletionResult
+from felix_agent_sdk.providers.types import CompletionResult, MessageRole
 
 from rle.agents.actions import ActionPlan, ActionPlanParseError
 from rle.agents.base_role import RimWorldRoleAgent
@@ -64,6 +64,46 @@ class TestConstruction:
     ) -> None:
         agent = _DummyRoleAgent("d-01", mock_provider, helix, spawn_time=0.0)
         assert agent._last_action_plan is None
+
+
+# ------------------------------------------------------------------
+# no-think prefill gating
+# ------------------------------------------------------------------
+
+
+class TestNoThinkPrefill:
+    def test_prefill_appended_for_openai_provider(
+        self, mock_provider: MagicMock, helix: HelixGeometry,
+    ) -> None:
+        mock_provider.provider_name = "openai"
+        agent = _DummyRoleAgent("d-01", mock_provider, helix, spawn_time=0.0)
+        agent.set_no_think(True)
+        agent._call_provider("sys", "user", 0.5, 100)
+
+        messages = mock_provider.complete.call_args[0][0]
+        assert messages[-1].role == MessageRole.ASSISTANT
+        assert messages[-1].content == "</think>"
+
+    def test_prefill_skipped_for_anthropic_provider(
+        self, mock_provider: MagicMock, helix: HelixGeometry,
+    ) -> None:
+        mock_provider.provider_name = "anthropic"
+        agent = _DummyRoleAgent("d-01", mock_provider, helix, spawn_time=0.0)
+        agent.set_no_think(True)
+        agent._call_provider("sys", "user", 0.5, 100)
+
+        messages = mock_provider.complete.call_args[0][0]
+        assert all(m.role != MessageRole.ASSISTANT for m in messages)
+
+    def test_no_prefill_when_disabled(
+        self, mock_provider: MagicMock, helix: HelixGeometry,
+    ) -> None:
+        mock_provider.provider_name = "openai"
+        agent = _DummyRoleAgent("d-01", mock_provider, helix, spawn_time=0.0)
+        agent._call_provider("sys", "user", 0.5, 100)
+
+        messages = mock_provider.complete.call_args[0][0]
+        assert all(m.role != MessageRole.ASSISTANT for m in messages)
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,50 @@
+"""Tests for RLEConfig API-key bridging."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from rle.config import RLEConfig, bridge_anthropic_key, bridge_openrouter_key
+
+
+class TestBridgeAnthropicKey:
+    def test_exports_key_to_process_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sentinel")
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
+        config = RLEConfig(anthropic_api_key="sk-ant-test")
+        bridge_anthropic_key(config)
+        assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-test"
+
+    def test_does_not_override_existing_env(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "from-env")
+        config = RLEConfig(anthropic_api_key="from-dotenv")
+        bridge_anthropic_key(config)
+        assert os.environ["ANTHROPIC_API_KEY"] == "from-env"
+
+    def test_noop_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sentinel")
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
+        config = RLEConfig(anthropic_api_key=None)
+        bridge_anthropic_key(config)
+        assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+class TestBridgeOpenRouterKey:
+    def test_exports_key_to_process_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sentinel")
+        monkeypatch.delenv("OPENAI_API_KEY")
+        config = RLEConfig(openrouter_api_key="sk-or-test")
+        bridge_openrouter_key(config)
+        assert os.environ["OPENAI_API_KEY"] == "sk-or-test"
+
+    def test_does_not_override_existing_env(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+        config = RLEConfig(openrouter_api_key="from-dotenv")
+        bridge_openrouter_key(config)
+        assert os.environ["OPENAI_API_KEY"] == "from-env"


### PR DESCRIPTION
## Why

Claude Fable 5 dropped today and we want to run it through RLE. The audit found three things that break any `--provider anthropic` run on Claude 4.6+ models (two hard 400s, one missing-credential path). Companion PR: AppSprout-dev/felix-agent-sdk#31 (temperature gating in the provider itself).

## What

- **`--no-think` prefill gated**: `RimWorldRoleAgent._call_provider` appended a trailing `</think>` assistant message on every provider path. Anthropic rejects assistant prefills with 400 — now skipped when `provider_name == "anthropic"`.
- **`extra_body` gated**: `run_benchmark.py --no-think` injected `chat_template_kwargs` (OpenAI-compatible escape hatch); the Anthropic API rejects unknown body fields. Now gated to non-anthropic providers (both the main and `--ablation` paths).
- **`ANTHROPIC_API_KEY` bridge**: pydantic-settings loads `.env` into the config object but not `os.environ`, where the felix provider looks. New `bridge_anthropic_key()` mirrors the OpenRouter bridge and is wired into both CLI scripts.

## Tests

406 pass (8 new: no-think gating × 3, key bridging × 5), ruff clean, mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)